### PR TITLE
Upgrade LIBVIRT to tag gardenlinux-release-26-05-19 (6896f4dade77f4b73bab6a04a622ef1e1ddaa869

### DIFF
--- a/.container
+++ b/.container
@@ -1,0 +1,1 @@
+ghcr.io/gardenlinux/repo-debian-snapshot@sha256:0348e829222f0e62c61cb68e630f1766b62e4311303bc35b02cbd5c62a98abef

--- a/.container
+++ b/.container
@@ -1,1 +1,1 @@
-ghcr.io/gardenlinux/repo-debian-snapshot@sha256:0348e829222f0e62c61cb68e630f1766b62e4311303bc35b02cbd5c62a98abef
+ghcr.io/gardenlinux/repo-debian-snapshot@sha256:99f72494ab45d33958a0385054de4742c7022ab07b4c0c2cef6f785f8ebfb378

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,15 @@ on:
       - main
       - rel-1877
       - sta-1877
+      - rel-2150
+      - sta-2150
   push:
     branches:
       - main
       - rel-1877
       - sta-1877
+      - rel-2150
+      - sta-2150
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'

--- a/prepare_source
+++ b/prepare_source
@@ -1,8 +1,8 @@
 # vim: ft=bash
 
 # commit sha from https://github.com/cyberus-technology/libvirt/commits/gardenlinux/
-LIBVIRT_COMMIT_SHA="db2f30fce426ff3f61de01874b2ee8a9aca43a7b"
-version_increment="7"
+LIBVIRT_COMMIT_SHA="6896f4dade77f4b73bab6a04a622ef1e1ddaa869"
+version_increment="8"
 
 git_src_commit "$LIBVIRT_COMMIT_SHA" https://github.com/cyberus-technology/libvirt.git
 

--- a/prepare_source
+++ b/prepare_source
@@ -2,7 +2,7 @@
 
 # commit sha from https://github.com/cyberus-technology/libvirt/commits/gardenlinux/
 LIBVIRT_COMMIT_SHA="db2f30fce426ff3f61de01874b2ee8a9aca43a7b"
-version_increment="6"
+version_increment="7"
 
 git_src_commit "$LIBVIRT_COMMIT_SHA" https://github.com/cyberus-technology/libvirt.git
 

--- a/prepare_source
+++ b/prepare_source
@@ -1,8 +1,8 @@
 # vim: ft=bash
 
 # commit sha from https://github.com/cyberus-technology/libvirt/commits/gardenlinux/
-LIBVIRT_COMMIT_SHA="55976a694dd7db37c110ef583e60a2421d188ccf"
-version_increment="5"
+LIBVIRT_COMMIT_SHA="db2f30fce426ff3f61de01874b2ee8a9aca43a7b"
+version_increment="6"
 
 git_src_commit "$LIBVIRT_COMMIT_SHA" https://github.com/cyberus-technology/libvirt.git
 
@@ -20,6 +20,6 @@ sed "s/SED_MARKER_FOR_COMMIT_SHA/$LIBVIRT_COMMIT_SHA/" <upstream_patches/meson.b
 apply_patches
 import_upstream_patches
 
-version="12.1.0-1"  # current debian base (do not change for rebuilds)
-version_suffix="gl${version_increment}"
+version="12.1.0-1" # current debian base (do not change for rebuilds)
+version_suffix="gl${version_increment}~bp2150"
 message="Update to $version $version_suffix"


### PR DESCRIPTION
- **[2150] initial build**
- **use correct repo for 2150**
- **Upgrade LIBVIRT to tag gardenlinux-release-26-05-19 (6896f4dade77f4b73bab6a04a622ef1e1ddaa869)**
