### PR TITLE
Upgrade LIBVIRT to tag gardenlinux-release-26-06-19 (2c1f90970ef88165447f65311ee990ed3b0ead01)

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,8 +1,8 @@
 # vim: ft=bash
 
 # commit sha from https://github.com/cyberus-technology/libvirt/commits/gardenlinux/
-LIBVIRT_COMMIT_SHA="6896f4dade77f4b73bab6a04a622ef1e1ddaa869"
-version_increment="1"
+LIBVIRT_COMMIT_SHA="2c1f90970ef88165447f65311ee990ed3b0ead01"
+version_increment="2"
 
 git_src_commit "$LIBVIRT_COMMIT_SHA" https://github.com/cyberus-technology/libvirt.git
 


### PR DESCRIPTION
Changelog from gardenlinux-release-26-06-16 which we include here:

* Fixed a Cloud Hypervisor driver double-free in virCHProcessEvents.
* Fixed a reboot/shutdown race in the Cloud Hypervisor driver that could leave the monitor stuck and lead to a SIGSEGV.
* Reverted the Cloud Hypervisor virtio-net offloading workaround.